### PR TITLE
Upgrade opusic-sys from 0.2.2 to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ repository = "https://github.com/DuckerMan/magnum-opus"
 documentation = "https://docs.rs/magnum-opus"
 
 [dependencies]
-opusic-sys = "0.2.2"
+opusic-sys = "0.3"
 libc = "0.2"


### PR DESCRIPTION
This upgrade is required for [important cross-compilation fixes](https://github.com/DoumanAsh/opusic-sys/pull/1).

BTW, could you enable the issue tracker for this repository? There’s nowhere to file issues that are specific to magnum-opus right now.